### PR TITLE
Updated h3pandas version and removed h3 pin

### DIFF
--- a/prep/pyproject.toml
+++ b/prep/pyproject.toml
@@ -38,8 +38,7 @@ dependencies = [
     "geopandas >= 0.14",
     "typer >= 0.8",
     "PyYAML ~= 6.0",
-    "h3pandas >= 0.2.3",
-    "h3 < 4",
+    "h3pandas >= 0.3.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
H3-pandas has released version 0.3.0, which solves the issue that was temporary solved with the h3 pin. 

I've updated the pyproject.toml to reflect this.

This was mostly done, due to having a Windows 11 user report an issue with installing spider with the h3 pin and I have tested it this updated way on both and they work!